### PR TITLE
Refactor paths and improve test utilities

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 import logging
-import os
 from http import HTTPMethod
+from pathlib import Path
 
 # region logging
 FILE_LOG_LEVEL = logging.ERROR
@@ -16,10 +16,10 @@ HTTP_METHODS = list(HTTPMethod)  # ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OP
 # endregion
 
 # region paths
-ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = Path(__file__).resolve().parent
 
-LOGS_PATH = os.path.join(ROOT_DIR, "logs")
-ALLURE_RESULTS_PATH = os.path.join(ROOT_DIR, "allure-results")
+LOGS_PATH = ROOT_DIR / "logs"
+ALLURE_RESULTS_PATH = ROOT_DIR / "allure-results"
 # endregion
 
 # region hosts

--- a/src/decorators/http_wrappers.py
+++ b/src/decorators/http_wrappers.py
@@ -1,6 +1,6 @@
 import uuid
 from functools import wraps
-from typing import Callable, TypeVar
+from typing import TYPE_CHECKING, Callable
 
 from requests import Response
 from requests.exceptions import HTTPError
@@ -9,7 +9,8 @@ from config import HTTP_METHODS
 from src.utils.allure_utils import add_request_attachments
 from src.utils.custom_logger import CustomLogger
 
-T = TypeVar("T", bound="CustomRequester")
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from src.utils.custom_requester import CustomRequester
 
 
 def log_response(logger: CustomLogger):
@@ -34,7 +35,7 @@ def log_request(logger: CustomLogger):
 
     def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(self: T, *args, **kwargs):
+        def wrapper(self: "CustomRequester", *args, **kwargs):
             request_id = kwargs.get("request_id", str(uuid.uuid4()))
             method = kwargs.get("method", "No HTTP method provided decorated")
             endpoint = kwargs.get("endpoint", "No endpoint provided decorated")
@@ -183,7 +184,7 @@ def send_request_wrapper(logger: CustomLogger):
         @log_response(logger)
         @log_request(logger)
         @check_status_code_400_799(logger)
-        def wrapper(self: T, *args, **kwargs):
+        def wrapper(self: "CustomRequester", *args, **kwargs):
             return func(self, *args, **kwargs)
 
         return wrapper

--- a/src/decorators/retries.py
+++ b/src/decorators/retries.py
@@ -1,4 +1,5 @@
 import time
+from contextlib import suppress
 from functools import wraps
 
 
@@ -14,14 +15,11 @@ def retry_on_exception(max_attempts=3, delay=1, exceptions=(Exception,)):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            for attempt in range(1, max_attempts + 1):
-                try:
+            for _ in range(max_attempts - 1):
+                with suppress(*exceptions):
                     return func(*args, **kwargs)
-                except exceptions:
-                    if attempt == max_attempts:
-                        raise
-                    time.sleep(delay)
-            return None
+                time.sleep(delay)
+            return func(*args, **kwargs)
 
         return wrapper
 

--- a/src/utils/custom_logger.py
+++ b/src/utils/custom_logger.py
@@ -21,12 +21,11 @@ class CustomLogger:
 
     def _initialize_logger(self) -> None:
         """Инициализирует логгер с настройками из конфига."""
-        os.makedirs(cfg.LOGS_PATH, exist_ok=True)
+        cfg.LOGS_PATH.mkdir(parents=True, exist_ok=True)
 
         # Очищаем или создаем файл лога
-        log_file = os.path.join(cfg.LOGS_PATH, cfg.LOG_FILE_NAME)
-        with open(log_file, "w", encoding="utf-8") as f:
-            f.write("")
+        log_file = cfg.LOGS_PATH / cfg.LOG_FILE_NAME
+        log_file.write_text("", encoding="utf-8")
 
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(cfg.FILE_LOG_LEVEL)
@@ -38,7 +37,7 @@ class CustomLogger:
             tz_hours_gap=3,
         )
 
-        self.file_log_handler = FileHandler(str(log_file), "a", encoding="utf-8")
+        self.file_log_handler = FileHandler(log_file, "a", encoding="utf-8")
         self.file_log_handler.setLevel(cfg.FILE_LOG_LEVEL)
         self.file_log_handler.setFormatter(formatter)
 

--- a/src/utils/custom_requester.py
+++ b/src/utils/custom_requester.py
@@ -151,7 +151,7 @@ class CustomRequester:
 
     # Хуки сессии (для логирования через session hooks)
     @staticmethod
-    def request_logging(response: Response, *args, **kwargs) -> Response:
+    def request_logging(response: Response, *_: object, **__: object) -> Response:
         """Логирует запрос ПОСЛЕ отправки (из объекта Response)."""
         log.info(
             f"Request: {response.request.method} {response.request.url}\n"
@@ -161,10 +161,10 @@ class CustomRequester:
         return response
 
     @staticmethod
-    def response_logging(response: Response, *args, **kwargs) -> Response:
+    def response_logging(response: Response, *_: object, **__: object) -> Response:
         """Логирует ответ сервера."""
         log.info(
             f"Response: {response.status_code} {response.url}\n"
-            f"Content: {response.text if response.text else {response.content}}\n",
+            f"Content: {response.text if response.text else response.content}\n",
         )
         return response

--- a/src/utils/utc_log_formatter.py
+++ b/src/utils/utc_log_formatter.py
@@ -7,6 +7,6 @@ class UtcFormatter(logging.Formatter):
         super().__init__(fmt=fmt, datefmt=datefmt, style=style, validate=validate)
         self.tz = timezone(timedelta(hours=tz_hours_gap))
 
-    def formatTime(self, record, datefmt=None):
+    def formatTime(self, record, datefmt=None):  # noqa: N802
         dt = datetime.fromtimestamp(record.created, tz=self.tz)
         return dt.strftime(datefmt) if datefmt else dt.isoformat()

--- a/tests/pet/test_pet.py
+++ b/tests/pet/test_pet.py
@@ -122,18 +122,20 @@ class TestPet:
     @allure.title("Создание и загрузка фото питомца")
     def test_upload_pet_photo(self, admin, pet_helper, pet_data):
         """Загрузка фото питомца"""
-        pytest.skip("Доделать загрузку файла (доразместить фото и проверить, что фото загружено)")
+        pytest.skip(
+            "Доделать загрузку файла (доразместить фото и проверить, что фото загружено)"
+        )
         # TODO: доделать загрузку файла (доразместить фото)
         # Сначала создаём питомца
-        response = pet_helper.create_pet(client, pet_data)
+        response = pet_helper.create_pet(admin, pet_data)
         CustomAsserts.assert_equal(response.name, pet_data.name)
 
         # Загружаем фото питомца
         photo_url = "https://example.com/dog2.jpg"
-        response = pet_helper.upload_image(client, pet_data.id, "dog2", photo_url)
+        response = pet_helper.upload_image(admin, pet_data.id, "dog2", photo_url)
 
         # Проверяем, что фото загружено
-        response = pet_helper.get_pet(client, pet_data.id)
+        response = pet_helper.get_pet(admin, pet_data.id)
         assert photo_url in response.photoUrls
 
     @allure.story("Обновление информации о питомцах")

--- a/utils/model_generation.py
+++ b/utils/model_generation.py
@@ -1,4 +1,4 @@
-import os
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -6,8 +6,8 @@ from postprocessing import replace_regex, replace_reserved_names
 from utils_for_gen import add_description_to_file, convert_to_utf8, get_description_from_yaml
 
 # Пути к папкам
-SPECS_DIR = "./src/resources/"  # Папка с файлами схем
-MODELS_DIR = "./src/models"  # Папка для сохранения сгенерированных моделей
+SPECS_DIR = Path("./src/resources/")  # Папка с файлами схем
+MODELS_DIR = Path("./src/models")  # Папка для сохранения сгенерированных моделей
 
 # Команда для datamodel-codegen
 GENERATOR_CMD = (
@@ -39,56 +39,51 @@ GENERATOR_CMD = (
 def generate_models():
     """Генерация моделей из файлов OpenAPI схем с использованием datamodel-codegen."""
     # Создаем папку models, если она не существует
-    Path(MODELS_DIR).mkdir(parents=True, exist_ok=True)
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
 
     # Рекурсивно обходим папку specs
-    for root, _, files in os.walk(SPECS_DIR):
-        for file in files:
-            if "OpenAPI.yml" in file:
-                # Полный путь к файлу схемы
-                input_file = os.path.join(root, file)
+    for input_file in SPECS_DIR.rglob("*OpenAPI.yml"):
+        # Конвертируем входной файл в utf-8
+        convert_to_utf8(input_file)
 
-                # Конвертируем входной файл в utf-8
-                convert_to_utf8(input_file)
+        # Извлекаем название микросервиса из имени файла
+        service_name = input_file.name.replace("OpenAPI.yml", "").strip()
 
-                # Извлекаем название микросервиса из имени файла
-                service_name = file.replace("OpenAPI.yml", "").strip()
+        # Создаем корректное имя для выходного файла
+        output_filename = f"{service_name}.py"
+        output_file = MODELS_DIR / output_filename
 
-                # Создаем корректное имя для выходного файла
-                output_filename = f"{service_name}.py"
-                output_file = os.path.join(MODELS_DIR, output_filename)
+        # Формируем команду для datamodel-codegen
+        cmd = GENERATOR_CMD.format(
+            input_file=input_file,
+            output_file=output_file,
+            input_file_type="openapi",
+        )
 
-                # Формируем команду для datamodel-codegen
-                cmd = GENERATOR_CMD.format(
-                    input_file=input_file,
-                    output_file=output_file,
-                    input_file_type="openapi",
-                )
+        print(f"Генерация моделей для {input_file} -> {output_file}")
+        try:
+            subprocess.run(shlex.split(cmd), check=True)  # noqa: S603
+        except subprocess.CalledProcessError as e:
+            print(f"Ошибка при генерации {output_filename}\n:{e}")
+            continue  # Пропускаем обработку этого файла при ошибке
 
-                print(f"Генерация моделей для {input_file} -> {output_file}")
-                try:
-                    subprocess.run(cmd, shell=True, check=True)
-                except subprocess.CalledProcessError as e:
-                    print(f"Ошибка при генерации {output_filename}\n:{e}")
-                    continue  # Пропускаем обработку этого файла при ошибке
+        try:
+            description = get_description_from_yaml(input_file)
+            add_description_to_file(output_file, description, service_name)
+        except Exception as e:
+            print(f"Ошибка при добавлении описания в файл {output_filename}\n:{e}")
 
-                try:
-                    description = get_description_from_yaml(input_file)
-                    add_description_to_file(output_file, description, service_name)
-                except Exception as e:
-                    print(f"Ошибка при добавлении описания в файл {output_filename}\n:{e}")
+        try:
+            replace_reserved_names(output_file)
+        except Exception as e:
+            print(
+                f"Ошибка при замене зарезервированных имен в файле {output_filename}\n:{e}"
+            )
 
-                try:
-                    replace_reserved_names(output_file)
-                except Exception as e:
-                    print(
-                        f"Ошибка при замене зарезервированных имен в файле {output_filename}\n:{e}"
-                    )
-
-                try:
-                    replace_regex(output_file)
-                except Exception as e:
-                    print(f"Ошибка при постобработке файла модели {output_filename}\n:{e}")
+        try:
+            replace_regex(output_file)
+        except Exception as e:
+            print(f"Ошибка при постобработке файла модели {output_filename}\n:{e}")
 
 
 if __name__ == "__main__":

--- a/utils/postprocessing.py
+++ b/utils/postprocessing.py
@@ -1,11 +1,14 @@
-def replace_base_model(file_path):
+from pathlib import Path
+
+
+def replace_base_model(file_path: str | Path):
     """Добавляет импорт BaseRequestModel и заменяет BaseModel на BaseRequestModel
     только в тех случаях, где BaseModel используется как базовый класс.
 
     @param file_path: Путь к файлу, в котором нужно произвести замену.
     """
-    with open(file_path, encoding="utf-8") as file:
-        content = file.read()
+    path = Path(file_path)
+    content = path.read_text(encoding="utf-8")
 
     lines = content.splitlines()
     new_lines = []
@@ -20,17 +23,16 @@ def replace_base_model(file_path):
 
     content = "\n".join(new_lines)
 
-    with open(file_path, "w", encoding="utf-8") as file:
-        file.write(content)
+    path.write_text(content, encoding="utf-8")
 
 
-def replace_regex(file_path):
+def replace_regex(file_path: str | Path):
     """Заменяет regex на pattern и удаляет unique_items.
 
     @param file_path: Путь к файлу, в котором нужно произвести замену.
     """
-    with open(file_path, encoding="utf-8") as file:
-        content = file.read()
+    path = Path(file_path)
+    content = path.read_text(encoding="utf-8")
 
     content = content.replace("regex", "pattern")
     content = content.replace(" unique_items=True, ", "")
@@ -46,26 +48,24 @@ def replace_regex(file_path):
     content = content.replace("UUID", "StrictStr")
     content = content.replace("from uuid import StrictStr", "")
 
-    with open(file_path, "w", encoding="utf-8") as file:
-        file.write(content)
+    path.write_text(content, encoding="utf-8")
 
 
-def replace_reserved_names(file_path):
+def replace_reserved_names(file_path: str | Path):
     """Заменяет зарезервированные имена полей на альтернативные.
 
     @param file_path: Путь к файлу, в котором нужно произвести замену.
     """
+    path = Path(file_path)
     reserved_names_mapping = {
         "date": "date_",
         "__root__": "root_non_filled",
     }  # Заменяем "date" на "date_"
 
-    with open(file_path, encoding="utf-8") as file:
-        content = file.read()
+    content = path.read_text(encoding="utf-8")
 
     for old_name, new_name in reserved_names_mapping.items():
         content = content.replace(f"{old_name}: ", f"{new_name}: ")
         content = content.replace(f'"{old_name}": ', f'"{new_name}": ')
 
-    with open(file_path, "w", encoding="utf-8") as file:
-        file.write(content)
+    path.write_text(content, encoding="utf-8")

--- a/utils/utils_for_gen.py
+++ b/utils/utils_for_gen.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Optional
 
 import chardet
@@ -6,12 +7,13 @@ import yaml
 CONFIDENCE_THRESHOLD = 0.7
 
 
-def detect_encoding(file_path: str) -> str:
+def detect_encoding(file_path: str | Path) -> str:
     """Detect the encoding of a file with a fallback to utf-8.
 
     @param file_path: Path to the file whose encoding is to be detected.
     """
-    with open(file_path, "rb") as file:
+    path = Path(file_path)
+    with path.open("rb") as file:
         raw_data = file.read(10000)  # Read first 10k bytes for efficiency
 
     result = chardet.detect(raw_data)
@@ -24,46 +26,47 @@ def detect_encoding(file_path: str) -> str:
     return encoding or "utf-8"  # Default to utf-8 if encoding is None
 
 
-def convert_to_utf8(file_path: str):
+def convert_to_utf8(file_path: str | Path) -> None:
     """Convert a file to UTF-8 encoding.
 
     Handles cases where the detected encoding might fail.
 
     @param file_path: Path to the file to be converted.
     """
+    path = Path(file_path)
     try:
         # First try with detected encoding
-        encoding = detect_encoding(file_path)
-        with open(file_path, encoding=encoding, errors="replace") as file:
+        encoding = detect_encoding(path)
+        with path.open(encoding=encoding, errors="replace") as file:
             content = file.read()
     except UnicodeDecodeError:
         # If detection fails, try common encodings with error handling
         encodings_to_try = ["utf-8", "cp1252", "iso-8859-1", "cp437"]
         for enc in encodings_to_try:
             try:
-                with open(file_path, encoding=enc, errors="strict") as file:
+                with path.open(encoding=enc, errors="strict") as file:
                     content = file.read()
                 break
             except UnicodeDecodeError:
                 continue
         else:
             # If all encodings fail, use replace mode to handle invalid chars
-            with open(file_path, encoding="utf-8", errors="replace") as file:
+            with path.open(encoding="utf-8", errors="replace") as file:
                 content = file.read()
 
     # Write back as UTF-8
-    with open(file_path, "w", encoding="utf-8") as file:
-        file.write(content)
+    path.write_text(content, encoding="utf-8")
 
 
-def get_description_from_yaml(file_path: str) -> Optional[str]:
+def get_description_from_yaml(file_path: str | Path) -> Optional[str]:
     """Extract the description from a YAML file.
 
     @param file_path: Path to the YAML file.
     @return: The description string or None.
     """
+    path = Path(file_path)
     try:
-        with open(file_path, encoding="utf-8") as file:
+        with path.open(encoding="utf-8") as file:
             yaml_content = yaml.safe_load(file)
         return yaml_content.get("info", {}).get("description", None)
     except (OSError, yaml.YAMLError, UnicodeDecodeError) as e:
@@ -71,20 +74,21 @@ def get_description_from_yaml(file_path: str) -> Optional[str]:
         return None
 
 
-def add_description_to_file(file_path: str, description: str, ms: str):
+def add_description_to_file(file_path: str | Path, description: str, ms: str) -> None:
     """Add a description comment to the beginning of a file.
 
     @param file_path: Path to the file where the description will be added.
     @param description: The description to be added.
     @param ms: The message to be added.
     """
+    path = Path(file_path)
     try:
-        with open(file_path, encoding="utf-8") as file:
+        with path.open(encoding="utf-8") as file:
             content = file.read()
 
         description_comment = f"# {ms}: {description}\n" if description else ""
 
-        with open(file_path, "w", encoding="utf-8") as file:
+        with path.open("w", encoding="utf-8") as file:
             file.write(description_comment + content)
     except OSError as e:
         print(f"Error processing file {file_path}: {e!s}")


### PR DESCRIPTION
## Summary
- use pathlib for path management and clean logging setup
- streamline retry logic and fix logging hooks
- stabilize model generation and test scaffolding

## Testing
- `ruff check`
- `ruff check --unsafe-fixes`
- `pytest tests/pet/test_pet.py::TestPet::test_create_pet -q`


------
https://chatgpt.com/codex/tasks/task_e_689631d521688321b73b88f4081a636d