### PR TITLE
Fix error logger capturing info messages

### DIFF
--- a/src/utils/custom_logger.py
+++ b/src/utils/custom_logger.py
@@ -64,7 +64,13 @@ class CustomLogger:
         self.queue_handler = QueueHandler(self.queue)
         self.logger.addHandler(self.queue_handler)
 
-        self.queue_listener = QueueListener(self.queue, *handlers)
+        # Ensure each handler processes only records at or above its level.
+        # Without ``respect_handler_level=True``, ``QueueListener`` dispatches
+        # every log record to all handlers, causing INFO messages to appear
+        # in ``error.log`` despite the handler's ERROR level.
+        self.queue_listener = QueueListener(
+            self.queue, *handlers, respect_handler_level=True
+        )
         self.queue_listener.start()
 
     def shutdown(self) -> None:


### PR DESCRIPTION
## Summary
- ensure QueueListener respects handler levels so error.log only receives error-level messages

## Testing
- `pytest -q --maxfail=1` *(fails: tests/pet/test_pet.py::TestPet::test_update_pet - AssertionError: Статус код 404 не равен ожидаемому 200)*

------
https://chatgpt.com/codex/tasks/task_e_68966be71ee08321a884de70cf984e4e